### PR TITLE
Capitalize component name in Footer.js

### DIFF
--- a/src/components/Footer.js
+++ b/src/components/Footer.js
@@ -3,7 +3,7 @@ import React from "react";
 import Typography from "@material-ui/core/Typography";
 import { makeStyles } from "@material-ui/core/styles";
 
-export default function footer() {
+export default function Footer() {
   const useStyles = makeStyles(theme => ({
     footer: {
       backgroundColor: theme.palette.background.paper,


### PR DESCRIPTION
Fixes error in bundle generation:
 "14:19  error  React Hook "useStyles" is called in function "footer" which is neither a React function component or a custom React Hook function  react-hooks/rules-of-hooks"